### PR TITLE
Format movie genres with a space and comma between each

### DIFF
--- a/src/components/SingleMovie/SingleMovieInfo.tsx
+++ b/src/components/SingleMovie/SingleMovieInfo.tsx
@@ -21,7 +21,7 @@ const SingleMovieTitle: FC<{ movie: Movie }> = ({ movie }) => {
       </Text>
       <Text style={styles.singleMovieInfo}>
         <Text style={styles.singleMovieInfoHeader}>Genres: </Text>
-        {movie.genres}
+        {movie.genres.join(', ')}
       </Text>
     </>
   );


### PR DESCRIPTION
### What was changed?

- Use `.join(', ')` to add space and comma between each genre